### PR TITLE
Add cross compiler for raspberry pi3 on ubuntu 22.04

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ubuntu2204_parallels"]
+	path = ubuntu2204_parallels
+	url = git@github.com:Linux-Kernel-Debugging/ubuntu2204_parallels.git


### PR DESCRIPTION
It was tested on parallels 18.0.1.53056 in macos Ventura 13.1